### PR TITLE
Join a room for current user.

### DIFF
--- a/utils/broadcast.js
+++ b/utils/broadcast.js
@@ -3,15 +3,13 @@ const getRightRoles = require("./getRightRoles.js");
 async function prepareBroadcast({ AB, req, object, data, dataId, event }) {
    const rooms = [];
    const roles = await getRightRoles(AB, object, data);
-   // const roles = [];
-   // const checkScope = (/*role, record*/) => true;
    roles.forEach((role) => {
-      // does the role have access?
-      // const hasAccess = checkScope(role, data);
-      // if (!hasAccess) return;
       const roomKey = `${object.id}-${role.uuid}`;
       rooms.push(req.socketKey(roomKey));
    });
+   // Also broadcast to the req user (need to figure how to handle updates when
+   // using current_user filter in scopes)
+   rooms.push(req.socketKey(`${object.id}-${req._user.username}`));
    return {
       room: rooms,
       event,

--- a/utils/getRightRoles.js
+++ b/utils/getRightRoles.js
@@ -3,7 +3,16 @@ const FilterComplex = require("../AppBuilder/platform/FilterComplex");
 function isDataValid(AB, scope, currentObject, data) {
    const filter_helper = new FilterComplex(null, AB);
    filter_helper.fieldsLoad(currentObject.fields(), currentObject);
-   filter_helper.setValue(scope?.Filters);
+   // We only need to add the rule related to the currentObject
+   const scopeRules = [];
+   if (scope.Filters && scope.Filters.rules) {
+      (scope.Filters.rules || []).forEach((r) => {
+         if (currentObject.fieldIDs.indexOf(r.key) > -1) {
+            scopeRules.push(r);
+         }
+      });
+   }
+   filter_helper.setValue({ glue: "and", rules: scopeRules });
 
    return (
       (scope.objectIds ?? []).filter((objId) => objId == currentObject.id)


### PR DESCRIPTION
So long story short. The way we broadcast updates based on scope will not work when we use a `current_user` filter since the rooms are not for a specific user.

As a work around, we can ensure that at least the req user who actually made the change should receive an update.

We may need to check against individual users if we find a current user filter?

related https://github.com/digi-serve/ab_service_api_sails/pull/32