### PR TITLE
Handle case of null `req._user`

### DIFF
--- a/utils/broadcast.js
+++ b/utils/broadcast.js
@@ -7,9 +7,11 @@ async function prepareBroadcast({ AB, req, object, data, dataId, event }) {
       const roomKey = `${object.id}-${role.uuid}`;
       rooms.push(req.socketKey(roomKey));
    });
-   // Also broadcast to the req user (need to figure how to handle updates when
-   // using current_user filter in scopes)
-   rooms.push(req.socketKey(`${object.id}-${req._user.username}`));
+   if (req._user) {
+      // Also broadcast to the req user (need to figure how to handle updates when
+      // using current_user filter in scopes)
+      rooms.push(req.socketKey(`${object.id}-${req._user.username}`));
+   }
    return {
       room: rooms,
       event,


### PR DESCRIPTION
This was the reason behind those Okta new user timeouts.

The `prepareBroadcast()` function would just silently fail if `_user` was null. And the parent service would timeout without getting any success/failure response.

However, I do not know what this broadcasting is even for. I won't be offended if you implement a totally different fix instead.