### PR TITLE
[wip] initial optimization to minimize the data returned for populated data

### DIFF
--- a/handlers/model-get.js
+++ b/handlers/model-get.js
@@ -163,11 +163,14 @@ module.exports = {
                               }
 
                               // clear any .password / .salt from SiteUser objects
-                              cleanReturnData(AB, object, result.data).then(
-                                 () => {
-                                    cb(null, result);
-                                 }
-                              );
+                              cleanReturnData(
+                                 AB,
+                                 object,
+                                 result.data,
+                                 cond.populate
+                              ).then(() => {
+                                 cb(null, result);
+                              });
                            })
                            .catch((err) => {
                               req.notify.developer(err, {

--- a/handlers/model-update.js
+++ b/handlers/model-update.js
@@ -77,7 +77,7 @@ module.exports = {
                });
             }
 
-            var oldItem = null;
+            // var oldItem = null;
             var newRow = null;
             const packets = [];
             async.series(
@@ -110,49 +110,52 @@ module.exports = {
                      }
                   },
 
-                  // 1) pull the old Item so we can compare updated connected
-                  // entries that need to be updated.
-                  findOld: (done) => {
-                     req.performance.mark("find.old");
-                     // RetryFind(
-                     //    object,
-                     //    {
-                     //       where: {
-                     //          glue: "and",
-                     //          rules: [
-                     //             {
-                     //                key: object.PK(),
-                     //                rule: "equals",
-                     //                value: id,
-                     //             },
-                     //          ],
-                     //       },
-                     //       populate: true,
-                     //    },
-                     //    condDefaults,
-                     //    req
-                     // )
-                     req.retry(() =>
-                        object
-                           .model()
-                           .find({ where: { uuid: id }, populate: true }, req)
-                     )
-                        .then((result) => {
-                           req.performance.measure("find.old");
-                           oldItem = result;
-                           done();
-                        })
-                        .catch((err) => {
-                           req.notify.developer(err, {
-                              context:
-                                 "Service:appbuilder.model-update: finding old entry:",
-                              req,
-                              id,
-                              // condDefaults,
-                           });
-                           done(err);
-                        });
-                  },
+                  // NOTE: oldItem was used when we sent out 'stale' updates.  But we no
+                  // longer perform that.  So, taking this out:
+                  //
+                  // // 1) pull the old Item so we can compare updated connected
+                  // // entries that need to be updated.
+                  // findOld: (done) => {
+                  //    req.performance.mark("find.old");
+                  //    // RetryFind(
+                  //    //    object,
+                  //    //    {
+                  //    //       where: {
+                  //    //          glue: "and",
+                  //    //          rules: [
+                  //    //             {
+                  //    //                key: object.PK(),
+                  //    //                rule: "equals",
+                  //    //                value: id,
+                  //    //             },
+                  //    //          ],
+                  //    //       },
+                  //    //       populate: true,
+                  //    //    },
+                  //    //    condDefaults,
+                  //    //    req
+                  //    // )
+                  //    req.retry(() =>
+                  //       object
+                  //          .model()
+                  //          .find({ where: { uuid: id }, populate: true }, req)
+                  //    )
+                  //       .then((result) => {
+                  //          req.performance.measure("find.old");
+                  //          oldItem = result;
+                  //          done();
+                  //       })
+                  //       .catch((err) => {
+                  //          req.notify.developer(err, {
+                  //             context:
+                  //                "Service:appbuilder.model-update: finding old entry:",
+                  //             req,
+                  //             id,
+                  //             // condDefaults,
+                  //          });
+                  //          done(err);
+                  //       });
+                  // },
 
                   // 2) Perform the Initial Update of the data
                   update: (done) => {


### PR DESCRIPTION
Testing out our initial fix for minimizing populated data.

We've been having slow performance and services crashing when trying to `JSON.stringify()` large data sets.

This set of fixes attempts to reduce the data we return in our populated data so we are encoding and transferring less data overall.