### PR TITLE
[add] config option for disabling / enabling the auto label update feature.

### DIFF
--- a/config/local.js
+++ b/config/local.js
@@ -10,6 +10,11 @@ module.exports = {
       /* enable: {bool} is this service active?                                */
       /*************************************************************************/
       enable: env("APPBUILDER_ENABLE", true),
+
+      /*************************************************************************/
+      /* labelUpdates: {bool} do we allow label update requests?               */
+      /*************************************************************************/
+      labelUpdates: env("APPBUILDER_LABEL_UPDATES", false),
    },
 
    /**

--- a/handlers/labelMissing.js
+++ b/handlers/labelMissing.js
@@ -57,6 +57,16 @@ module.exports = {
     */
    fn: function handler(req, cb) {
       //
+      req.log("appbuilder.labelMissing");
+
+      // verify we have enabled the ability to update labels.
+      let config = req.config();
+      if (!config.labelUpdates) {
+         // if not, simply log the attempt and act as if everything was fine.
+         req.log("appbuilder.labelMissing -> labelUpdates not enabled.");
+         cb(null, { status: "success" });
+         return;
+      }
 
       // Get the passed in parameters
       var labelsToTranslate = req.param("labels");


### PR DESCRIPTION
On production sites, we don't want to auto add the untranslated labels to our translation files.