### PR TITLE
Fix Process Trigger Wrong Inputs Error

### DIFF
--- a/handlers/model-update.js
+++ b/handlers/model-update.js
@@ -265,6 +265,25 @@ module.exports = {
                                     )
                                  )[0];
 
+                                 // Getting some request with pureData = null
+                                 // which causes an invalid
+                                 // process_manager.trigger request. Catch that
+                                 // case here so we have more context. (The
+                                 // error will get handled later in
+                                 // utils/processTrigger/manager.js)
+                                 if (!pureData) {
+                                    req.notify.developer(
+                                       new Error(
+                                          "Unexpected response from model.find()"
+                                       ),
+                                       {
+                                          context:
+                                             "appbuilder.model-update trigger() missing data for process trigger request",
+                                          params: req.params(),
+                                       }
+                                    );
+                                 }
+
                                  await registerProcessTrigger(req, {
                                     key: `${object.id}.updated`,
                                     data: pureData,


### PR DESCRIPTION
digi-serve/ab_service_process_manager#81
Fixes Sentry AB-APPBUILDER-1J
- turns out 2 bad requests got into the queue and will continue to be retried. (data = `null`);
- add notify to better understand how the request got bad input data initially.
## Release Notes
<!-- #release_notes -->
- Remove requests with Invalid Inputs from the Queue so they don't retry
- Report context when the expected input data is null
<!-- /release_notes --> 
