### PR TITLE
Fix: we need to trigger a full user cache reset when role/scope changes

### DIFF
--- a/utils/cacheManager.js
+++ b/utils/cacheManager.js
@@ -12,24 +12,26 @@ async function clearCache(AB, req, objID, uuid) {
    if (AffectedObjects.indexOf(objID) == -1) return;
 
    // invalidate our Site Cache
-   req.serviceRequest(
-      "api_sails.site-cache-stale",
-      {
-         tenantID: req.tenantID,
-      },
-      () => {}
-   );
-
+   req.serviceRequest("api_sails.site-cache-stale", {
+      tenantID: req.tenantID,
+   }).catch(() => {});
+   if (!uuid) return;
+   const jobData = {
+      tenantID: req.tenantID,
+   };
    // if this was effecting a specific user, then invalidate user cache
    if (objID == "228e3d91-5e42-49ec-b37c-59323ae433a1" && uuid) {
-      req.serviceRequest(
-         "api_sails.user-cache-stale",
-         {
-            tenantID: req.tenantID,
-            userUUID: uuid,
-         },
-         () => {}
-      );
+      jobData.userUUID = uuid;
    }
+   // If role/scope Changed
+   else if (
+      objID === "c33692f3-26b7-4af3-a02e-139fb519296d" ||
+      objID === "af10e37c-9b3a-4dc6-a52a-85d52320b659"
+   ) {
+      // Need to clear all cached user, because a role/scope assingment may have been
+      // added or removed
+      jobData.userUUID = "all";
+   }
+   req.serviceRequest("api_sails.user-cache-stale", jobData).catch(() => {});
 }
 module.exports = { clearCache };


### PR DESCRIPTION
Requires these changes in API: https://github.com/digi-serve/ab_service_api_sails/pull/142
## Release Notes
<!-- #release_notes -->
- Trigger a full user cache reset when role/scope changes
<!-- /release_notes --> 
