### PR TITLE
Optimise our Relation operations

### DIFF
--- a/handlers/model-update.js
+++ b/handlers/model-update.js
@@ -459,7 +459,7 @@ function updateData(AB, object, id, values, userData, req) {
    // Do Knex update data tasks
    return new Promise((resolve, reject) => {
       // retryUpdate(object, id, values, userData, req)
-      req.retry(() => object.model().update(id, values, userData))
+      req.retry(() => object.model().update(id, values, userData, null, req))
          .then((fullEntry) => {
             resolve(fullEntry);
          })


### PR DESCRIPTION
When tracking down an operation that took over 25 minutes to complete, I discovered some very inefficient methods of performing UPDATEs with our relation data.

This patch is a revamp to the code to minimize the amount of work we do during those operations.

This is expected to work with [platform#130](https://github.com/digi-serve/appbuilder_platform_service/pull/130)

## Release Notes
<!-- #release_notes -->
- [wip] model.update() now takes a req parameter
<!-- /release_notes --> 

## Test Status
most of the existing tests in the Kitchensink app that relate to DataCollections cover the correct operation of these changes.
