### PR TITLE
CSV Packing of Data (appbuilder service)

### DIFF
--- a/handlers/csv-export.js
+++ b/handlers/csv-export.js
@@ -274,9 +274,10 @@ let getSQL = (
                   case "string":
                   case "LongText":
                      if (f.isMultilingual) {
-                        let transCol = (obj instanceof AB.Class.ABObjectQuery
-                           ? "`{prefix}.translations`"
-                           : "{prefix}.translations"
+                        let transCol = (
+                           obj instanceof AB.Class.ABObjectQuery
+                              ? "`{prefix}.translations`"
+                              : "{prefix}.translations"
                         ).replace("{prefix}", f.dbPrefix().replace(/`/g, ""));
 
                         let languageCode =

--- a/handlers/labels.js
+++ b/handlers/labels.js
@@ -11,7 +11,7 @@ var Labels = require("../AppBuilder/core/labels/labels");
 // and returns those when requested.
 
 function getLabels(req, langCode) {
-   return new Promise((resolve, reject) => {
+   return new Promise((resolve /*, reject */) => {
       if (!Labels[langCode]) {
          var error = new Error(
             `No label definitions for language_code=[${langCode}]`

--- a/handlers/model-delete.js
+++ b/handlers/model-delete.js
@@ -10,7 +10,7 @@ const Errors = require("../utils/Errors");
 const {
    registerProcessTrigger,
 } = require("../utils/processTrigger/manager.js");
-const UpdateConnectedFields = require("../utils/broadcastUpdateConnectedFields.js");
+// const UpdateConnectedFields = require("../utils/broadcastUpdateConnectedFields.js");
 const { prepareBroadcast } = require("../utils/broadcast.js");
 const { clearCache } = require("../utils/cacheManager.js");
 
@@ -120,8 +120,6 @@ module.exports = {
                         .then((num) => {
                            numRows = num;
                            req.performance.measure("delete");
-                           // End the API call here:
-                           // cb(null, { numRows });
                            done();
                         })
                         .catch((err) => {

--- a/handlers/model-get.js
+++ b/handlers/model-get.js
@@ -206,6 +206,17 @@ module.exports = {
             });
          }
 
+         // let preCSVPackBytes = JSON.stringify(result).length;
+         // csv pack our results
+         result = object.model().csvPack(result);
+         // let postCSVPackBytes = JSON.stringify(result).length;
+         // req.log(
+         //    `CSV Pack: ${preCSVPackBytes} -> ${postCSVPackBytes} (${(
+         //       (postCSVPackBytes / preCSVPackBytes) *
+         //       100
+         //    ).toFixed(2)}%)`
+         // );
+
          cb(null, result);
       } catch (err) {
          req.notify.developer(err, {

--- a/handlers/model-post.js
+++ b/handlers/model-post.js
@@ -6,7 +6,7 @@ const async = require("async");
 const ABBootstrap = require("../AppBuilder/ABBootstrap");
 const cleanReturnData = require("../AppBuilder/utils/cleanReturnData");
 const Errors = require("../utils/Errors");
-const UpdateConnectedFields = require("../utils/broadcastUpdateConnectedFields.js");
+// const UpdateConnectedFields = require("../utils/broadcastUpdateConnectedFields.js");
 const { prepareBroadcast } = require("../utils/broadcast.js");
 const {
    registerProcessTrigger,
@@ -66,6 +66,7 @@ module.exports = {
             var condDefaults = req.userDefaults();
 
             var newRow = null;
+            var newRowPacked = null;
             const packets = [];
             async.series(
                {
@@ -108,6 +109,7 @@ module.exports = {
                            cleanReturnData(AB, object, [data]).then(() => {
                               // pull out the new row for use in our other steps
                               newRow = data;
+                              newRowPacked = object.model().csvPack({ data });
 
                               // proceed with the process
                               done(null, data);
@@ -152,6 +154,8 @@ module.exports = {
                         req,
                         object,
                         data: newRow,
+                        dataPacked: newRowPacked,
+                        dataId: newRow[PK],
                         event: "ab.datacollection.create",
                      })
                         .then((packet) => {
@@ -174,7 +178,7 @@ module.exports = {
                   serviceResponse: (done) => {
                      // So let's end the service call here, then proceed
                      // with the rest
-                     cb(null, newRow);
+                     cb(null, newRowPacked);
                      done();
                   },
 

--- a/handlers/model-update.js
+++ b/handlers/model-update.js
@@ -7,7 +7,7 @@ const async = require("async");
 const ABBootstrap = require("../AppBuilder/ABBootstrap");
 const cleanReturnData = require("../AppBuilder/utils/cleanReturnData");
 const Errors = require("../utils/Errors");
-const RetryFind = require("../utils/RetryFind");
+// const RetryFind = require("../utils/RetryFind");
 // const UpdateConnectedFields = require("../utils/broadcastUpdateConnectedFields.js");
 const { prepareBroadcast } = require("../utils/broadcast.js");
 const {
@@ -80,6 +80,7 @@ module.exports = {
 
             // var oldItem = null;
             var newRow = null;
+            var newRowPacked = null;
             const packets = [];
             async.series(
                {
@@ -165,8 +166,9 @@ module.exports = {
                            req.performance.measure("update");
                            cleanReturnData(AB, object, [result]).then(() => {
                               newRow = result;
-                              // end the api call here
-                              // cb(null, result);
+                              newRowPacked = object
+                                 .model()
+                                 .csvPack({ data: result });
 
                               // proceed with the process
                               done(null, result);
@@ -185,6 +187,8 @@ module.exports = {
                         req,
                         object,
                         data: newRow,
+                        dataPacked: newRowPacked,
+                        dataId: id,
                         event: "ab.datacollection.update",
                      })
                         .then((packet) => {
@@ -206,7 +210,7 @@ module.exports = {
                   serviceResponse: (done) => {
                      // So let's end the service call here, then proceed
                      // with the rest
-                     cb(null, newRow);
+                     cb(null, newRowPacked);
                      done();
                   },
 

--- a/handlers/netsuite-data-verify.js
+++ b/handlers/netsuite-data-verify.js
@@ -33,7 +33,7 @@ module.exports = {
       let table = req.param("table");
       let credentials = Netsuite.importCredentials(req);
 
-      let sql = `SELECT * FROM ${table};`;
+      // let sql = `SELECT * FROM ${table};`;
       try {
          // let resultsSQL = await Netsuite.query(credentials, sql, 10, 0);
          let results = await Netsuite.queryAPI(credentials, table, "");

--- a/utils/broadcast.js
+++ b/utils/broadcast.js
@@ -1,6 +1,13 @@
-const getRightRoles = require("./getRightRoles.js");
+// const getRightRoles = require("./getRightRoles.js");
 
-async function prepareBroadcast({ AB, req, object, data, dataId, event }) {
+async function prepareBroadcast({
+   /*AB,*/ req,
+   object,
+   data,
+   dataPacked,
+   dataId,
+   event,
+}) {
    const rooms = [];
    /*
     * DEPRECIATED Approach: {object}-{role} method
@@ -18,10 +25,13 @@ async function prepareBroadcast({ AB, req, object, data, dataId, event }) {
    */
 
    // now we create rooms {tenantID}-{id}
-   // NOTE: we EITHER have dataId OR data, so check each one for our id
+
    let id = dataId;
-   if (data) {
-      id = data[object.PK()];
+   if (!id) {
+      // try to pull from an existing data entry
+      if (data && data[object.PK()]) {
+         id = data[object.PK()];
+      }
    }
    rooms.push(req.socketKey(id)); // req.socketKey() adds {tenantID}-
 
@@ -52,7 +62,7 @@ async function prepareBroadcast({ AB, req, object, data, dataId, event }) {
       event,
       data: {
          objectId: object.id,
-         data: data ?? dataId,
+         data: dataPacked ?? data ?? dataId,
          jobID: req.jobID ?? "??",
       },
       copyTo,


### PR DESCRIPTION
Initial Implementation of CSV Packing of our Data.

Currently we have been using json as our exchange format between our client and server.  For for larger data sets, the json format repeats a lot of data for the field names. ex:
```
[ 
	{
		"firstName": "Neo",
		"lastName" : "Andersong",
	},
	{
		"firstName": "Morpheous",
		"lastName" : "",
	},
	{
		"firstName": "Trinity",
		"lastName" : ""
	}
]
```

using csv, we can reduce the repeated column information:
```
firstName,lastName
"Neo","Anderson"
"Morpheous",""
"Trinity",""
```

The larger the dataset, the greater the savings. 

The previous data exchange format was
```
{
    data: [{obj1}, {obj2}, ... {objN}],
    total_bytes:xx,
}
```
This change now encodes our data in the following format:
```
{
  csv_packed:{
    data: "csv of primary data",
    relations: {
      {connectionFieldID}: "csv of relation data", // each entry has entry._csvID, that is the lookup
      {connectionFieldID}: "csv of relation data",
      ...
  }
  total_bytes:xx,
}
```

This will happen for any direct request to the appbuilder.model-get, model-patch, model-update services as well as any broadcast that happens as a result of one of those operations.

This PR is part of a series of updates: [class_core](https://github.com/digi-serve/appbuilder_class_core/pull/290), [platform_web](https://github.com/digi-serve/ab_platform_web/pull/646), [platform_service](https://github.com/digi-serve/appbuilder_platform_service/pull/168), [appbuilder service](https://github.com/digi-serve/ab_service_appbuilder/pull/119)

## Release Notes
<!-- #release_notes -->
- [wip] implementing CSV Packing of data on Service Platform
<!-- /release_notes --> 

## Test Status
Actually, I've been using the existing Kitchensink app as our tests. This should be working as expected if that keeps working out all the variations of data being exchanged between the client and server.
